### PR TITLE
Add package for FWaaS v2 logging

### DIFF
--- a/Ingration guideline for logging service in FWaaS.rst
+++ b/Ingration guideline for logging service in FWaaS.rst
@@ -15,7 +15,7 @@ Environment
 
   .. code-block:: console
 
-    sudo apt-get install libnetfilter-log1
+    sudo apt-get install libnetfilter-log1 python-zmq
 	
 * Devstack local.conf:  http://paste.openstack.org/show/725188/
   


### PR DESCRIPTION
This commit adds a new package `python-zmq` to work q-l3.service correctly.